### PR TITLE
Fix rosdeps for Noetic

### DIFF
--- a/robotiq/package.xml
+++ b/robotiq/package.xml
@@ -8,9 +8,7 @@
   <url type="website">http://ros.org/wiki/robotiq</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <exec_depend>robotiq_3f_gripper_visualization</exec_depend>
   <exec_depend>robotiq_modbus_tcp</exec_depend>
-  <exec_depend>robotiq_3f_gripper_control</exec_depend>
   <exec_depend>robotiq_2f_gripper_control</exec_depend>
   <exec_depend>robotiq_ft_sensor</exec_depend>
 

--- a/robotiq_modbus_rtu/package.xml
+++ b/robotiq_modbus_rtu/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>python-pymodbus</depend>
+  <depend>python3-pymodbus</depend>
   <depend>rospy</depend>
 
 </package>

--- a/robotiq_modbus_tcp/package.xml
+++ b/robotiq_modbus_tcp/package.xml
@@ -10,6 +10,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>python-pymodbus</depend>
+  <depend>python3-pymodbus</depend>
   <depend>rospy</depend>
 </package>


### PR DESCRIPTION
# Description
Removes all mention of the 3f gripper from package.xml

Also changes `python-modbus` -> `python3-modbus`

# How to Test
Try:
```sh
cd <INTO_THIS_REPO>
rosdep install --from-paths . --ignore-src --rosdistro=noetic 
```

If you do it before, it will complain a bunch and stop installing as soon as it hits an error.
After this PR, it completes the rosdep install as expected